### PR TITLE
use env variable for jwt secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This will initialize or update the database schema to the latest version.
 
 ## Run the Go backend:
 
+Make sure the `JWT_SECRET` environment variable is set before starting the server.
+
 ```sh
 go run cmd/main.go
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"log"
+	"os"
+)
+
+var JWTSecret = loadJWTSecret()
+
+func loadJWTSecret() []byte {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		log.Println("Warning: JWT_SECRET not set, using default secret")
+		secret = "default-secret"
+	}
+	return []byte(secret)
+}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -4,12 +4,11 @@ import (
 	"net/http"
 	"time"
 
+	"diet-app-backend/config"
 	"diet-app-backend/models"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 )
-
-var jwtSecret = []byte("C*Wz#As2p+E6r1vNfYqKjBmSuHqXpZoRvTgYhJuQmBrNvZkTpWqRzXnCgVmSjGfLt") //generate new and move to env
 
 func Login(c *gin.Context) {
 	var credentials models.User
@@ -30,7 +29,7 @@ func Login(c *gin.Context) {
 		"exp":      time.Now().Add(time.Hour * 1).Unix(),
 	})
 
-	tokenString, err := token.SignedString(jwtSecret)
+	tokenString, err := token.SignedString(config.JWTSecret)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Errore nella generazione del token"})
 		return

--- a/middleware/jwt.go
+++ b/middleware/jwt.go
@@ -5,11 +5,10 @@ import (
 	"net/http"
 	"strings"
 
+	"diet-app-backend/config"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
 )
-
-var jwtSecret = []byte("C*Wz#As2p+E6r1vNfYqKjBmSuHqXpZoRvTgYhJuQmBrNvZkTpWqRzXnCgVmSjGfLt") // Assicurati che sia la stessa del login
 
 func JWTMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -31,7 +30,7 @@ func JWTMiddleware() gin.HandlerFunc {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, jwt.ErrSignatureInvalid
 			}
-			return jwtSecret, nil
+			return config.JWTSecret, nil
 		})
 
 		if err != nil || !token.Valid {


### PR DESCRIPTION
## Summary
- centralize JWT secret loading in new config package
- use config.JWTSecret in auth handler and JWT middleware
- document JWT_SECRET requirement in README

## Testing
- `gofmt -w handlers/auth.go middleware/jwt.go config/config.go`
- `go vet ./...` *(fails: could not download Go 1.24 toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684036d9f9f4832fa70f08760a3cf584