### PR TITLE
Improve auth security and add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ This will initialize or update the database schema to the latest version.
 migrate -path db/migrations -database "postgres://postgres:postgres@localhost:5432/dietappdb?sslmode=disable" up
 ```
 
+## 🔒 Authentication
+
+User credentials are now stored with Argon2 hashed passwords. Demo accounts are:
+
+- `dietista1` / `password123`
+- `dietista2` / `password456`
+
+## 🩺 Health Check
+
+To verify the service is running, call:
+
+```sh
+curl http://localhost:8080/healthz
+```
+
 This will initialize or update the database schema to the latest version.
 
 ## Run the Go backend:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,8 +16,11 @@ func main() {
 	router := gin.Default()
 
 	// Middleware globali (sempre eseguiti)
-	router.Use(middleware.CORSMiddleware())
-	router.Use(middleware.LoggingMiddleware())
+       router.Use(middleware.CORSMiddleware())
+       router.Use(middleware.LoggingMiddleware())
+
+       // Basic health check
+       router.GET("/healthz", handlers.HealthCheck)
 
 	// Rotta pubblica per il login
 	router.POST("/login", handlers.Login)

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -17,11 +17,10 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	expectedPassword, exists := models.Users[credentials.Username]
-	if !exists || expectedPassword != credentials.Password {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Credenziali non valide"})
-		return
-	}
+       if !models.VerifyUser(credentials.Username, credentials.Password) {
+               c.JSON(http.StatusUnauthorized, gin.H{"error": "Credenziali non valide"})
+               return
+       }
 
 	// Creazione del token JWT
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{

--- a/handlers/health.go
+++ b/handlers/health.go
@@ -1,0 +1,9 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+// HealthCheck returns a simple status response.
+func HealthCheck(c *gin.Context) {
+    c.JSON(200, gin.H{"status": "ok"})
+}
+

--- a/models/users.go
+++ b/models/users.go
@@ -1,11 +1,34 @@
 package models
 
+import (
+    "encoding/hex"
+    "golang.org/x/crypto/argon2"
+)
+
+// User represents login credentials sent by the client.
 type User struct {
-	Username string
-	Password string
+    Username string `json:"username"`
+    Password string `json:"password"`
 }
 
+const passwordSalt = "dietapp_salt"
+
+func hashPassword(p string) string {
+    hash := argon2.IDKey([]byte(p), []byte(passwordSalt), 1, 64*1024, 4, 32)
+    return hex.EncodeToString(hash)
+}
+
+// Users stores demo users with hashed passwords.
 var Users = map[string]string{
-	"dietista1": "password123",
-	"dietista2": "password456",
+    "dietista1": hashPassword("password123"),
+    "dietista2": hashPassword("password456"),
+}
+
+// VerifyUser returns true when the provided credentials are valid.
+func VerifyUser(username, password string) bool {
+    hash, exists := Users[username]
+    if !exists {
+        return false
+    }
+    return hash == hashPassword(password)
 }


### PR DESCRIPTION
## Summary
- hash demo user passwords with Argon2
- verify credentials with the new hash
- add `/healthz` endpoint
- document authentication and health check in README

## Testing
- `go test ./...` *(fails: go toolchain cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_6840385f1b2c832fade3f3ee7fab4f65