### PR TITLE
Add Pact contract generation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ This will initialize or update the database schema to the latest version.
 migrate -path db/migrations -database "postgres://postgres:postgres@localhost:5432/dietappdb?sslmode=disable" up
 ```
 
+## 🧪 Consumer-Driven Contracts
+
+Pact files are stored in the `contracts/` directory. After writing your consumer tests with [pact-go](https://github.com/pact-foundation/pact-go), install the dependency and run the contract tests:
+
+```sh
+go get github.com/pact-foundation/pact-go/v2
+go test ./contracts -run TestPatientContract
+```
+
+Once generated, the patient contract can be retrieved from the running server at `GET /contracts/patient`.
+
 This will initialize or update the database schema to the latest version.
 
 ## Run the Go backend:

--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ migrate -path db/migrations -database "postgres://postgres:postgres@localhost:54
 
 ## 🧪 Consumer-Driven Contracts
 
-Pact files are stored in the `contracts/` directory. After writing your consumer tests with [pact-go](https://github.com/pact-foundation/pact-go), install the dependency and run the contract tests:
+Pact files are stored in the `contracts/` directory. After writing your consumer
+tests with [pact-go](https://github.com/pact-foundation/pact-go), install the
+CLI and the FFI library, then run the contract tests:
 
 ```sh
+pact-go install      # downloads the pact FFI library
 go get github.com/pact-foundation/pact-go/v2
 go test ./contracts -run TestPatientContract
 ```

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,9 @@ func main() {
 	// Rotta pubblica per il login
 	router.POST("/login", handlers.Login)
 
+	// Serve Pact contracts
+	router.GET("/contracts/patient", handlers.GetPactContract)
+
 	// Rotte protette da JWT middleware
 	auth := router.Group("/api/v1")
 	auth.Use(middleware.JWTMiddleware())

--- a/contracts/patient.json
+++ b/contracts/patient.json
@@ -1,0 +1,8 @@
+{
+  "consumer": {"name": "DietApp Frontend"},
+  "provider": {"name": "DietApp Backend"},
+  "interactions": [],
+  "metadata": {
+    "pactSpecification": {"version": "2.0.0"}
+  }
+}

--- a/contracts/patient_pact_test.go
+++ b/contracts/patient_pact_test.go
@@ -1,0 +1,53 @@
+package contracts
+
+import (
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "testing"
+
+    "diet-app-backend/models"
+    "github.com/pact-foundation/pact-go/v2/consumer"
+    "github.com/pact-foundation/pact-go/v2/matchers"
+)
+
+func TestPatientContract(t *testing.T) {
+    mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
+        Consumer: "DietApp Frontend",
+        Provider: "DietApp Backend",
+        PactDir:  "./contracts",
+    })
+    if err != nil {
+        t.Fatalf("failed to create pact: %v", err)
+    }
+
+    err = mockProvider.
+        AddInteraction().
+        Given("Patient 1 exists").
+        UponReceiving("A request for patient 1").
+        WithRequest(http.MethodGet, "/patients/1").
+        WillRespondWith(http.StatusOK, func(b *consumer.V2ResponseBuilder) {
+            b.BodyMatch(&models.Patient{})
+        }).
+        ExecuteTest(t, func(cfg consumer.MockServerConfig) error {
+            resp, err := http.Get(fmt.Sprintf("http://%s:%d/patients/1", cfg.Host, cfg.Port))
+            if err != nil {
+                return err
+            }
+            defer resp.Body.Close()
+            if resp.StatusCode != http.StatusOK {
+                return fmt.Errorf("expected status 200, got %d", resp.StatusCode)
+            }
+            var p models.Patient
+            if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+                return err
+            }
+            if p.ID == 0 {
+                return fmt.Errorf("expected non-zero patient id")
+            }
+            return nil
+        })
+    if err != nil {
+        t.Fatalf("pact verification failed: %v", err)
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
         gorm.io/driver/postgres v1.6.0 // indirect
         gorm.io/gorm v1.30.0 // indirect
-       github.com/pact-foundation/pact-go/v2 v2.0.0 // indirect
+       github.com/pact-foundation/pact-go/v2 v2.4.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorm.io/driver/postgres v1.6.0 // indirect
-	gorm.io/gorm v1.30.0 // indirect
+        gorm.io/driver/postgres v1.6.0 // indirect
+        gorm.io/gorm v1.30.0 // indirect
+       github.com/pact-foundation/pact-go/v2 v2.0.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -105,3 +105,5 @@ gorm.io/gorm v1.30.0 h1:qbT5aPv1UH8gI99OsRlvDToLxW5zR7FzS9acZDOZcgs=
 gorm.io/gorm v1.30.0/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
+github.com/pact-foundation/pact-go/v2 v2.4.1 h1:eaLC58qzeCTbwdlCY8UvWz1HmDW+qrjTFfH8Xoq0rWs=
+github.com/pact-foundation/pact-go/v2 v2.4.1/go.mod h1:OwnXXRliPZvKDMJn/IsAwQ95tQprmp5gPTzPYz54mTg=

--- a/handlers/contracts.go
+++ b/handlers/contracts.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetPactContract serves the Pact contract for the patient API.
+func GetPactContract(c *gin.Context) {
+	path := filepath.Join("contracts", "patient.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "contract not found"})
+		return
+	}
+	c.Data(http.StatusOK, "application/json", data)
+}


### PR DESCRIPTION
## Summary
- install pact-go dependency
- document contract generation in README
- implement Pact consumer test to generate patient contract

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24)*

------
https://chatgpt.com/codex/tasks/task_e_68403e7095c0832f9a403c930f6ffa40