### PR TITLE
Configure nginx for client-side routing

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,5 +7,6 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -15,6 +15,11 @@ npm run build     # crea i file di produzione
 Una volta buildato con `docker compose up --build`, il servizio `frontend` sarà
 disponibile su [http://localhost:3000](http://localhost:3000).
 
+### Routing lato client
+
+La configurazione di Nginx include la direttiva `try_files` per servire sempre `index.html`.
+In questo modo la navigazione tramite React Router funziona anche ricaricando manualmente la pagina.
+
 ## Cambiare tema
 
 Il tema predefinito è definito in `tailwind.config.js` nella sezione `daisyui` con il nome `mytheme`.

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- serve index.html for unknown routes
- document nginx router setup for React Router

## Testing
- `npm ci`
- `npm run lint`
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68418901d890832f87fc4e55470c6b1d