### PR TITLE
Add dietists model, migrations and handlers

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -1,298 +1,354 @@
-swagger: "2.0"
-host: localhost:8080   # Cambia in app:8080 quando usi Docker Compose
-basePath: /
-schemes:
-  - http
-
-securityDefinitions:
-  BearerAuth:
-    type: apiKey
-    name: Authorization
-    in: header
-
-security:
-  - BearerAuth: []
-
 definitions:
-  Diet:
-    properties:
-      created_at:
-        format: date-time
-        type: string
-        x-go-name: CreatedAt
-      description:
-        type: string
-        x-go-name: Description
-      id:
-        format: uint64
-        type: integer
-        x-go-name: ID
-      name:
-        type: string
-        x-go-name: Name
-      patient_id:
-        format: uint64
-        type: integer
-        x-go-name: PatientID
-    type: object
-    x-go-package: diet-app-backend/models
-  Patient:
-    properties:
-      created_at:
-        format: date-time
-        type: string
-        x-go-name: CreatedAt
-      diets:
-        description: |-
-          Diets holds all diets associated with the patient.
-          GORM will use PatientID as the foreign key by default, which matches
-          the Diet model's PatientID field.
-        items:
-          $ref: '#/definitions/Diet'
-        type: array
-        x-go-name: Diets
-      id:
-        format: uint64
-        type: integer
-        x-go-name: ID
-      name:
-        type: string
-        x-go-name: Name
-      username:
-        type: string
-        x-go-name: Username
-    type: object
-    x-go-package: diet-app-backend/models
-  User:
-    properties:
-      Password:
-        type: string
-      Username:
-        type: string
-    type: object
-    x-go-package: diet-app-backend/models
+    Diet:
+        properties:
+            created_at:
+                format: date-time
+                type: string
+                x-go-name: CreatedAt
+            description:
+                type: string
+                x-go-name: Description
+            id:
+                format: uint64
+                type: integer
+                x-go-name: ID
+            name:
+                type: string
+                x-go-name: Name
+            patient_id:
+                format: uint64
+                type: integer
+                x-go-name: PatientID
+        type: object
+        x-go-package: diet-app-backend/models
+    Dietist:
+        properties:
+            created_at:
+                format: date-time
+                type: string
+                x-go-name: CreatedAt
+            id:
+                format: uint64
+                type: integer
+                x-go-name: ID
+            name:
+                type: string
+                x-go-name: Name
+            password:
+                type: string
+                x-go-name: Password
+            username:
+                type: string
+                x-go-name: Username
+        type: object
+        x-go-package: diet-app-backend/models
+    Patient:
+        properties:
+            created_at:
+                format: date-time
+                type: string
+                x-go-name: CreatedAt
+            id:
+                format: uint64
+                type: integer
+                x-go-name: ID
+            name:
+                type: string
+                x-go-name: Name
+            username:
+                type: string
+                x-go-name: Username
+        type: object
+        x-go-package: diet-app-backend/models
+    User:
+        properties:
+            Password:
+                type: string
+            Username:
+                type: string
+        type: object
+        x-go-package: diet-app-backend/models
 paths:
-  /api/v1/patients:
-    get:
-      operationId: getPatients
-      responses:
-        "200":
-          $ref: '#/responses/patientsResponse'
-      summary: Returns all patients.
-      tags:
-        - patients
-    post:
-      operationId: createPatient
-      responses:
-        "201":
-          $ref: '#/responses/patientResponse'
-      summary: Create a new patient.
-      tags:
-        - patients
-  /api/v1/patients/{patientId}:
-    delete:
-      operationId: deletePatient
-      parameters:
-        - format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-      responses:
-        "204":
-          description: ""
-      summary: Delete a patient.
-      tags:
-        - patients
-    get:
-      operationId: getPatientByID
-      parameters:
-        - format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-      responses:
-        "200":
-          $ref: '#/responses/patientResponse'
-      summary: Returns a patient by ID.
-      tags:
-        - patients
-    put:
-      operationId: updatePatient
-      parameters:
-        - format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-      responses:
-        "200":
-          $ref: '#/responses/patientResponse'
-      summary: Update an existing patient.
-      tags:
-        - patients
-  /api/v1/patients/{patientId}/diets:
-    get:
-      operationId: getDiets
-      parameters:
-        - description: Patient ID
-          format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
-      responses:
-        "200":
-          $ref: '#/responses/dietsResponse'
-      summary: Retrieve all diets for a patient.
-      tags:
-        - diets
-    post:
-      operationId: createDiet
-      parameters:
-        - description: Patient ID
-          format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
-      responses:
-        "201":
-          $ref: '#/responses/dietResponse'
-      summary: Create a new diet for a patient.
-      tags:
-        - diets
-  /api/v1/patients/{patientId}/diets/{id}:
-    delete:
-      operationId: deleteDiet
-      parameters:
-        - description: Patient ID
-          format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
-      responses:
-        "204":
-          description: ""
-      summary: Delete a diet.
-      tags:
-        - diets
-    get:
-      operationId: getDietByID
-      parameters:
-        - description: Patient ID
-          format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
-      responses:
-        "200":
-          $ref: '#/responses/dietResponse'
-      summary: Retrieve a diet by ID.
-      tags:
-        - diets
-    put:
-      operationId: updateDiet
-      parameters:
-        - description: Patient ID
-          format: uint64
-          in: path
-          name: patientId
-          required: true
-          type: integer
-          x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
-      responses:
-        "200":
-          $ref: '#/responses/dietResponse'
-      summary: Update an existing diet.
-      tags:
-        - diets
-  /login:
-    post:
-      security: []
-      operationId: login
-      parameters:
-        - in: body
-          name: Body
-          schema:
-            $ref: '#/definitions/User'
-      responses:
-        "200":
-          $ref: '#/responses/tokenResponse'
-      summary: Authenticate user and return JWT token.
-      tags:
-        - auth
+    /api/v1/dietists:
+        get:
+            operationId: getDietists
+            responses:
+                "200":
+                    $ref: '#/responses/dietistsResponse'
+            summary: Returns all dietists.
+            tags:
+                - dietists
+        post:
+            operationId: createDietist
+            responses:
+                "201":
+                    $ref: '#/responses/dietistResponse'
+            summary: Create a new dietist.
+            tags:
+                - dietists
+    /api/v1/dietists/{dietistId}:
+        delete:
+            operationId: deleteDietist
+            parameters:
+                - format: uint64
+                  in: path
+                  name: dietistId
+                  required: true
+                  type: integer
+                  x-go-name: DietistID
+            responses:
+                "204":
+                    description: ""
+            summary: Delete a dietist.
+            tags:
+                - dietists
+        get:
+            operationId: getDietistByID
+            parameters:
+                - format: uint64
+                  in: path
+                  name: dietistId
+                  required: true
+                  type: integer
+                  x-go-name: DietistID
+            responses:
+                "200":
+                    $ref: '#/responses/dietistResponse'
+            summary: Returns a dietist by ID.
+            tags:
+                - dietists
+        put:
+            operationId: updateDietist
+            parameters:
+                - format: uint64
+                  in: path
+                  name: dietistId
+                  required: true
+                  type: integer
+                  x-go-name: DietistID
+            responses:
+                "200":
+                    $ref: '#/responses/dietistResponse'
+            summary: Update an existing dietist.
+            tags:
+                - dietists
+    /api/v1/patients:
+        get:
+            operationId: getPatients
+            responses:
+                "200":
+                    $ref: '#/responses/patientsResponse'
+            summary: Returns all patients.
+            tags:
+                - patients
+        post:
+            operationId: createPatient
+            responses:
+                "201":
+                    $ref: '#/responses/patientResponse'
+            summary: Create a new patient.
+            tags:
+                - patients
+    /api/v1/patients/{patientId}:
+        delete:
+            operationId: deletePatient
+            parameters:
+                - format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+            responses:
+                "204":
+                    description: ""
+            summary: Delete a patient.
+            tags:
+                - patients
+        get:
+            operationId: getPatientByID
+            parameters:
+                - format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+            responses:
+                "200":
+                    $ref: '#/responses/patientResponse'
+            summary: Returns a patient by ID.
+            tags:
+                - patients
+        put:
+            operationId: updatePatient
+            parameters:
+                - format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+            responses:
+                "200":
+                    $ref: '#/responses/patientResponse'
+            summary: Update an existing patient.
+            tags:
+                - patients
+    /api/v1/patients/{patientId}/diets:
+        get:
+            operationId: getDiets
+            parameters:
+                - description: Patient ID
+                  format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+            responses:
+                "200":
+                    $ref: '#/responses/dietsResponse'
+            summary: Retrieve all diets for a patient.
+            tags:
+                - diets
+        post:
+            operationId: createDiet
+            parameters:
+                - description: Patient ID
+                  format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+            responses:
+                "201":
+                    $ref: '#/responses/dietResponse'
+            summary: Create a new diet for a patient.
+            tags:
+                - diets
+    /api/v1/patients/{patientId}/diets/{id}:
+        delete:
+            operationId: deleteDiet
+            parameters:
+                - description: Patient ID
+                  format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+                - description: Diet ID (for diet operations)
+                  format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "204":
+                    description: ""
+            summary: Delete a diet.
+            tags:
+                - diets
+        get:
+            operationId: getDietByID
+            parameters:
+                - description: Patient ID
+                  format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+                - description: Diet ID (for diet operations)
+                  format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "200":
+                    $ref: '#/responses/dietResponse'
+            summary: Retrieve a diet by ID.
+            tags:
+                - diets
+        put:
+            operationId: updateDiet
+            parameters:
+                - description: Patient ID
+                  format: uint64
+                  in: path
+                  name: patientId
+                  required: true
+                  type: integer
+                  x-go-name: PatientID
+                - description: Diet ID (for diet operations)
+                  format: uint64
+                  in: path
+                  name: id
+                  required: true
+                  type: integer
+                  x-go-name: ID
+            responses:
+                "200":
+                    $ref: '#/responses/dietResponse'
+            summary: Update an existing diet.
+            tags:
+                - diets
+    /login:
+        post:
+            operationId: login
+            parameters:
+                - in: body
+                  name: Body
+                  schema:
+                    $ref: '#/definitions/User'
+            responses:
+                "200":
+                    $ref: '#/responses/tokenResponse'
+            summary: Authenticate user and return JWT token.
+            tags:
+                - auth
 responses:
-  dietResponse:
-    description: ""
-    schema:
-      $ref: '#/definitions/Diet'
-  dietsResponse:
-    description: ""
-    schema:
-      items:
-        $ref: '#/definitions/Diet'
-      type: array
-  patientResponse:
-    description: ""
-    schema:
-      $ref: '#/definitions/Patient'
-  patientsResponse:
-    description: ""
-    schema:
-      items:
-        $ref: '#/definitions/Patient'
-      type: array
-  tokenResponse:
-    description: ""
-    schema:
-      properties:
-        token:
-          type: string
-          x-go-name: Token
-      type: object
+    dietResponse:
+        description: ""
+        schema:
+            $ref: '#/definitions/Diet'
+    dietistResponse:
+        description: ""
+        schema:
+            $ref: '#/definitions/Dietist'
+    dietistsResponse:
+        description: ""
+        schema:
+            items:
+                $ref: '#/definitions/Dietist'
+            type: array
+    dietsResponse:
+        description: ""
+        schema:
+            items:
+                $ref: '#/definitions/Diet'
+            type: array
+    patientResponse:
+        description: ""
+        schema:
+            $ref: '#/definitions/Patient'
+    patientsResponse:
+        description: ""
+        schema:
+            items:
+                $ref: '#/definitions/Patient'
+            type: array
+    tokenResponse:
+        description: ""
+        schema:
+            properties:
+                token:
+                    type: string
+                    x-go-name: Token
+            type: object
+swagger: "2.0"

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -26,6 +26,12 @@ func main() {
 	auth := router.Group("/api/v1")
 	auth.Use(middleware.JWTMiddleware())
 	{
+		auth.GET("/dietists", handlers.GetDietists)
+		auth.GET("/dietists/:dietistId", handlers.GetDietistByID)
+		auth.POST("/dietists", handlers.CreateDietist)
+		auth.PUT("/dietists/:dietistId", handlers.UpdateDietist)
+		auth.DELETE("/dietists/:dietistId", handlers.DeleteDietist)
+
 		auth.GET("/patients", handlers.GetPatients)
 		auth.GET("/patients/:patientId", handlers.GetPatientByID)
 		auth.POST("/patients", handlers.CreatePatient)

--- a/backend/db/migrations/000003_create_dietists_table.down.sql
+++ b/backend/db/migrations/000003_create_dietists_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS dietists;

--- a/backend/db/migrations/000003_create_dietists_table.up.sql
+++ b/backend/db/migrations/000003_create_dietists_table.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS dietists (
+    id SERIAL PRIMARY KEY,
+    username TEXT NOT NULL UNIQUE,
+    password TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"diet-app-backend/config"
+	"diet-app-backend/db"
 	"diet-app-backend/models"
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
@@ -23,8 +24,12 @@ func Login(c *gin.Context) {
 		return
 	}
 
-	expectedPassword, exists := models.Users[credentials.Username]
-	if !exists || expectedPassword != credentials.Password {
+	var dietist models.Dietist
+	if err := db.DB.Where("username = ?", credentials.Username).First(&dietist).Error; err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Credenziali non valide"})
+		return
+	}
+	if dietist.Password != credentials.Password {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Credenziali non valide"})
 		return
 	}

--- a/backend/handlers/dietists.go
+++ b/backend/handlers/dietists.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"diet-app-backend/db"
+	"diet-app-backend/models"
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+// swagger:route GET /api/v1/dietists dietists getDietists
+// Returns all dietists.
+//
+// responses:
+//
+//	200: dietistsResponse
+func GetDietists(c *gin.Context) {
+	var dietists []models.Dietist
+	if err := db.DB.Find(&dietists).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch dietists"})
+		return
+	}
+	c.JSON(http.StatusOK, dietists)
+}
+
+// swagger:route GET /api/v1/dietists/{dietistId} dietists getDietistByID
+// Returns a dietist by ID.
+//
+// responses:
+//
+//	200: dietistResponse
+func GetDietistByID(c *gin.Context) {
+	id := c.Param("dietistId")
+	var dietist models.Dietist
+	if err := db.DB.First(&dietist, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Dietist not found"})
+		return
+	}
+	c.JSON(http.StatusOK, dietist)
+}
+
+// swagger:route POST /api/v1/dietists dietists createDietist
+// Create a new dietist.
+//
+// responses:
+//
+//	201: dietistResponse
+func CreateDietist(c *gin.Context) {
+	var dietist models.Dietist
+	if err := c.ShouldBindJSON(&dietist); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := db.DB.Create(&dietist).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not create dietist"})
+		return
+	}
+	c.JSON(http.StatusCreated, dietist)
+}
+
+// swagger:route PUT /api/v1/dietists/{dietistId} dietists updateDietist
+// Update an existing dietist.
+//
+// responses:
+//
+//	200: dietistResponse
+func UpdateDietist(c *gin.Context) {
+	id := c.Param("dietistId")
+	var dietist models.Dietist
+	if err := db.DB.First(&dietist, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Dietist not found"})
+		return
+	}
+	if err := c.ShouldBindJSON(&dietist); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := db.DB.Save(&dietist).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not update dietist"})
+		return
+	}
+	c.JSON(http.StatusOK, dietist)
+}
+
+// swagger:route DELETE /api/v1/dietists/{dietistId} dietists deleteDietist
+// Delete a dietist.
+//
+// responses:
+//
+//	204:
+func DeleteDietist(c *gin.Context) {
+	id := c.Param("dietistId")
+	if err := db.DB.Delete(&models.Dietist{}, id).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not delete dietist"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/backend/handlers/docs.go
+++ b/backend/handlers/docs.go
@@ -67,3 +67,22 @@ type dietsResponseWrapper struct {
 	// in:body
 	Body []models.Diet
 }
+
+// swagger:parameters getDietistByID updateDietist deleteDietist
+type dietistParams struct {
+	// in:path
+	// required: true
+	DietistID uint `json:"dietistId"`
+}
+
+// swagger:response dietistResponse
+type dietistResponseWrapper struct {
+	// in:body
+	Body models.Dietist
+}
+
+// swagger:response dietistsResponse
+type dietistsResponseWrapper struct {
+	// in:body
+	Body []models.Dietist
+}

--- a/backend/models/dietist.go
+++ b/backend/models/dietist.go
@@ -1,0 +1,12 @@
+package models
+
+import "time"
+
+// swagger:model
+type Dietist struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	Username  string    `json:"username"`
+	Name      string    `json:"name"`
+	Password  string    `json:"password,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/backend/models/users.go
+++ b/backend/models/users.go
@@ -6,7 +6,4 @@ type User struct {
 	Password string
 }
 
-var Users = map[string]string{
-	"dietista1": "password123",
-	"dietista2": "password456",
-}
+var Users = map[string]string{}


### PR DESCRIPTION
## Summary
- add Dietist model with password support
- create migrations for dietists table
- implement CRUD handlers for dietists
- register dietists routes
- update JWT login to use dietists from DB
- extend swagger docs and regenerate openapi spec

## Testing
- `go test ./...` *(fails: Forbidden downloading module)*
- `make openapi`

------
https://chatgpt.com/codex/tasks/task_e_6841a9514184832fbd5f9ebf5caed6b8