### PR TITLE
Fix diet endpoints Swagger parameters

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -146,13 +146,6 @@ paths:
           required: true
           type: integer
           x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
       responses:
         "200":
           $ref: '#/responses/dietsResponse'
@@ -169,13 +162,6 @@ paths:
           required: true
           type: integer
           x-go-name: PatientID
-        - description: Diet ID (for diet operations)
-          format: uint64
-          in: path
-          name: id
-          required: true
-          type: integer
-          x-go-name: ID
       responses:
         "201":
           $ref: '#/responses/dietResponse'


### PR DESCRIPTION
## Summary
- remove `id` parameter from list and create diet endpoints in swagger spec
- regenerate OpenAPI spec for diets

## Testing
- `go test ./...` *(fails: Get https://... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6841a95a16b8832f927765a7aca16951