### PR TITLE
Add admin page and seed admin user

### DIFF
--- a/backend/db/migrations/000004_insert_admin_dietist.down.sql
+++ b/backend/db/migrations/000004_insert_admin_dietist.down.sql
@@ -1,0 +1,1 @@
+DELETE FROM dietists WHERE username = 'admin';

--- a/backend/db/migrations/000004_insert_admin_dietist.up.sql
+++ b/backend/db/migrations/000004_insert_admin_dietist.up.sql
@@ -1,0 +1,3 @@
+INSERT INTO dietists (username, password, name)
+VALUES ('admin', 'admin', 'Administrator')
+ON CONFLICT DO NOTHING;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { AuthProvider } from './AuthContext'
 import Login from './pages/Login'
 import Patients from './pages/Patients'
 import PatientDiets from './pages/PatientDiets'
+import Admin from './pages/Admin'
 import Layout from './Layout'
 
 function App() {
@@ -14,6 +15,7 @@ function App() {
             <Route path="/login" element={<Login />} />
             <Route path="/patients" element={<Patients />} />
             <Route path="/patients/:id" element={<PatientDiets />} />
+            <Route path="/admin" element={<Admin />} />
             <Route path="*" element={<Navigate to="/login" replace />} />
           </Routes>
         </Layout>

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,130 @@
+import { useContext, useEffect, useState } from 'react'
+import AuthContext from '../AuthContext'
+
+export default function Admin() {
+  const { token } = useContext(AuthContext)
+  const [dietists, setDietists] = useState([])
+  const [username, setUsername] = useState('')
+  const [name, setName] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState(null)
+
+  const fetchDietists = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/api/v1/dietists', {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error('Failed to load')
+      setDietists(await res.json())
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  useEffect(() => { fetchDietists() }, [token])
+
+  const createDietist = async (e) => {
+    e.preventDefault()
+    try {
+      const res = await fetch('http://localhost:8080/api/v1/dietists', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ username, name, password }),
+      })
+      if (!res.ok) throw new Error('Creation failed')
+      setUsername('')
+      setPassword('')
+      setName('')
+      await fetchDietists()
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const deleteDietist = async (id) => {
+    await fetch(`http://localhost:8080/api/v1/dietists/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    await fetchDietists()
+  }
+
+  const updateDietist = async (d) => {
+    await fetch(`http://localhost:8080/api/v1/dietists/${d.id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ username: d.username, name: d.name, password: d.password }),
+    })
+    await fetchDietists()
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Dietists</h1>
+      <form onSubmit={createDietist} className="space-x-2">
+        <input
+          className="input input-bordered"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <input
+          className="input input-bordered"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <input
+          className="input input-bordered"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button className="btn btn-primary" type="submit">Add</button>
+      </form>
+      {error && <div className="text-red-500">{error}</div>}
+      <ul className="space-y-2">
+        {dietists.map((d) => (
+          <li key={d.id} className="card bg-base-100 shadow p-4">
+            <div className="flex justify-between items-center">
+              <div className="flex-1 space-x-2">
+                <input
+                  className="input input-bordered input-sm"
+                  value={d.username}
+                  onChange={(e) =>
+                    setDietists((prev) => prev.map((x) => (x.id === d.id ? { ...x, username: e.target.value } : x)))
+                  }
+                />
+                <input
+                  className="input input-bordered input-sm"
+                  value={d.name}
+                  onChange={(e) =>
+                    setDietists((prev) => prev.map((x) => (x.id === d.id ? { ...x, name: e.target.value } : x)))
+                  }
+                />
+                <input
+                  className="input input-bordered input-sm"
+                  type="password"
+                  value={d.password || ''}
+                  onChange={(e) =>
+                    setDietists((prev) => prev.map((x) => (x.id === d.id ? { ...x, password: e.target.value } : x)))
+                  }
+                />
+              </div>
+              <div className="space-x-2">
+                <button className="btn btn-sm" onClick={() => updateDietist(d)}>Save</button>
+                <button className="btn btn-sm btn-error" onClick={() => deleteDietist(d.id)}>Delete</button>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/admin` route to the React app
- implement `Admin` page for managing dietists
- seed an `admin` dietist via new migrations

## Testing
- `go test ./...` *(fails: Forbidden download)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b4dd3dd8832fa0024cf9bb133e9c