### PR TITLE
Update dietist model for email-based auth

### DIFF
--- a/backend/api/openapi.yaml
+++ b/backend/api/openapi.yaml
@@ -1,18 +1,3 @@
-swagger: "2.0"
-host: localhost:8080
-basePath: /
-schemes:
-  - http
-
-securityDefinitions:
-  BearerAuth:
-    type: apiKey
-    name: Authorization
-    in: header
-
-security:
-  - BearerAuth: []
-
 definitions:
     Diet:
         properties:
@@ -42,19 +27,22 @@ definitions:
                 format: date-time
                 type: string
                 x-go-name: CreatedAt
+            email:
+                type: string
+                x-go-name: Email
+            first_name:
+                type: string
+                x-go-name: FirstName
             id:
                 format: uint64
                 type: integer
                 x-go-name: ID
-            name:
-                type: string
-                x-go-name: Name
             password:
                 type: string
                 x-go-name: Password
-            username:
+            surname:
                 type: string
-                x-go-name: Username
+                x-go-name: Surname
         type: object
         x-go-package: diet-app-backend/models
     Patient:
@@ -63,14 +51,19 @@ definitions:
                 format: date-time
                 type: string
                 x-go-name: CreatedAt
-            id:
-                format: uint64
-                type: integer
-                x-go-name: ID
             dietist_id:
                 format: uint64
                 type: integer
                 x-go-name: DietistID
+            diets:
+                items:
+                    $ref: '#/definitions/Diet'
+                type: array
+                x-go-name: Diets
+            id:
+                format: uint64
+                type: integer
+                x-go-name: ID
             name:
                 type: string
                 x-go-name: Name
@@ -81,9 +74,9 @@ definitions:
         x-go-package: diet-app-backend/models
     User:
         properties:
-            Password:
+            Email:
                 type: string
-            Username:
+            Password:
                 type: string
         type: object
         x-go-package: diet-app-backend/models
@@ -370,3 +363,4 @@ responses:
                     type: string
                     x-go-name: Token
             type: object
+swagger: "2.0"

--- a/backend/db/migrations/000004_insert_admin_dietist.up.sql
+++ b/backend/db/migrations/000004_insert_admin_dietist.up.sql
@@ -1,3 +1,3 @@
-INSERT INTO dietists (username, password, name)
-VALUES ('admin', 'admin', 'Administrator')
+INSERT INTO dietists (first_name, surname, email, password)
+VALUES ('Admin', 'Administrator', 'admin@example.com', 'admin')
 ON CONFLICT DO NOTHING;

--- a/backend/db/migrations/000006_alter_dietists_table.down.sql
+++ b/backend/db/migrations/000006_alter_dietists_table.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE dietists
+    ADD COLUMN username TEXT NOT NULL UNIQUE,
+    ADD COLUMN name TEXT NOT NULL;
+
+ALTER TABLE dietists
+    DROP COLUMN IF EXISTS first_name,
+    DROP COLUMN IF EXISTS surname,
+    DROP COLUMN IF EXISTS email;

--- a/backend/db/migrations/000006_alter_dietists_table.up.sql
+++ b/backend/db/migrations/000006_alter_dietists_table.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE dietists
+    ADD COLUMN first_name TEXT NOT NULL,
+    ADD COLUMN surname TEXT NOT NULL,
+    ADD COLUMN email TEXT NOT NULL UNIQUE;
+
+ALTER TABLE dietists
+    DROP COLUMN IF EXISTS username,
+    DROP COLUMN IF EXISTS name;

--- a/backend/handlers/auth.go
+++ b/backend/handlers/auth.go
@@ -25,7 +25,7 @@ func Login(c *gin.Context) {
 	}
 
 	var dietist models.Dietist
-	if err := db.DB.Where("username = ?", credentials.Username).First(&dietist).Error; err != nil {
+	if err := db.DB.Where("email = ?", credentials.Email).First(&dietist).Error; err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Credenziali non valide"})
 		return
 	}
@@ -36,7 +36,7 @@ func Login(c *gin.Context) {
 
 	// Creazione del token JWT
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-		"username":   credentials.Username,
+		"email":      dietist.Email,
 		"dietist_id": dietist.ID,
 		"exp":        time.Now().Add(time.Hour * 1).Unix(),
 	})

--- a/backend/models/dietist.go
+++ b/backend/models/dietist.go
@@ -5,8 +5,9 @@ import "time"
 // swagger:model
 type Dietist struct {
 	ID        uint      `gorm:"primaryKey" json:"id"`
-	Username  string    `json:"username"`
-	Name      string    `json:"name"`
+	FirstName string    `json:"first_name"`
+	Surname   string    `json:"surname"`
+	Email     string    `gorm:"unique" json:"email"`
 	Password  string    `json:"password,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 }

--- a/backend/models/users.go
+++ b/backend/models/users.go
@@ -2,7 +2,7 @@ package models
 
 // swagger:model
 type User struct {
-	Username string
+	Email    string
 	Password string
 }
 


### PR DESCRIPTION
## Summary
- adjust dietist model to use first name, surname and email
- migrate dietists table for new columns and add admin user with them
- change user model and authentication flow to use email
- regenerate OpenAPI spec

## Testing
- `go test ./...` *(fails: forbidden fetching dependencies)*
- `make openapi`


------
https://chatgpt.com/codex/tasks/task_e_68482a8ba3b8832fa691d0250b21a852